### PR TITLE
fix(deploy): pin Node 22.x — Vercel was stuck on discontinued Node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
         "tailwind-scrollbar": "^3.0.5",
         "tailwindcss": "^3.4.3",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "portfolio-2.0",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Why every Vercel deploy failed (even after #92)

The Vercel build log showed the build dying **before install**:

> `Found invalid or discontinued Node.js Version: "18.x". Please set Node.js Version to 24.x in your Project Settings`

Two-part fix:
1. **Project setting updated** (already done via Vercel API using your logged-in CLI): `portfolio-2-0` → Node **22.x** (matches your local Node 22.18).
2. **This PR** pins `engines.node: 22.x` in `package.json` so the requirement lives in code and can't silently drift again.

I also triggered a production redeploy of `main` to verify the settings fix — status reported in chat.

### Verification
- `npm install` clean, `npm run build` / `npm run lint` / `tsc --noEmit` unchanged and green (only `engines` added + lockfile timestamp).

### Revert
Revert the single commit. Note the dashboard setting stays at 22.x either way (revert would only remove the in-code pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)