### PR TITLE
chore: framer-motion → motion v12 (rebranded package)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@heroicons/react": "^2.2.0",
         "@sanity/image-url": "^2.1.1",
-        "framer-motion": "^11.18.2",
+        "motion": "^12.42.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.81.0",
@@ -2976,13 +2976,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -4470,19 +4470,45 @@
         "pathe": "^2.0.1"
       }
     },
-    "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^11.18.1"
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@sanity/image-url": "^2.1.1",
-    "framer-motion": "^11.18.2",
+    "motion": "^12.42.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import { urlFor } from '../lib/sanity'
 import type { PageInfo } from '../types'

--- a/src/components/BackgroundCircles.tsx
+++ b/src/components/BackgroundCircles.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 const BackgroundCircles = () => {
   return (

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -1,5 +1,5 @@
 import { EnvelopeIcon, MapPinIcon, PhoneIcon } from '@heroicons/react/24/solid'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 import type { PageInfo } from '../types'

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import { urlFor } from '../lib/sanity'
 import type { Experience } from '../types'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { SocialIcon } from 'react-social-icons'
 
 import type { Social } from '../types'

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import { urlFor } from '../lib/sanity'
 import type { Project } from '../types'

--- a/src/components/Skill.tsx
+++ b/src/components/Skill.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import { urlFor } from '../lib/sanity'
 import type { Skill as SkillType } from '../types'

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import type { Skill as SkillType } from '../types'
 import Skill from './Skill'

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 
 import type { Experience } from '../types'
 import ExperienceCard from './ExperienceCard'


### PR DESCRIPTION
## PR 5 — `chore/motion-v12` (roadmap §4)

Swaps `framer-motion@11` for its rebranded successor `motion@12`. Imports in the 9 animated components change from `'framer-motion'` to `'motion/react'` — the API surface we use (`motion.div`/`motion.img`, `initial`/`animate`/`whileInView`/`viewport`/`transition`) is identical, so this is a package-name change, not a behavior change.

### Verification
- `npm install` clean, **0 vulnerabilities** ✅
- `npm run build` (prefetch + tsc + vite) green ✅
- `npm run lint` clean ✅
- Preview build checked: header slide-in, background circles ping/pulse, typewriter all animating; browser console completely clean ✅

Based directly on `main` (post-#97) — no stacking.

### Revert
Single commit revert restores framer-motion 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)