### PR TITLE
feat: update site content to resume + curate Skills grid (Goal 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # local resume source docs (content source of truth, not site assets)
 resume.md
 oldResume.md
+WPPOpen.png

--- a/sanity/schemas/skill.ts
+++ b/sanity/schemas/skill.ts
@@ -25,6 +25,14 @@ export default defineType({
       options: {
         hotspot: true
       }
+    },
+    {
+      name: 'showInSkills',
+      title: 'Show in Skills grid',
+      type: 'boolean',
+      description:
+        'When off, this skill is hidden from the Skills grid but can still be used as a technology tag on experience/project cards. Defaults to shown.',
+      initialValue: true
     }
   ]
 })

--- a/scripts/curate-skills.mjs
+++ b/scripts/curate-skills.mjs
@@ -1,0 +1,53 @@
+/**
+ * One-off content op: hides resume-irrelevant skills from the Skills grid
+ * by setting showInSkills=false. The documents are NOT deleted — they remain
+ * valid technology-tag targets on experience/project cards, so those card
+ * icons are preserved. Reversible by flipping the flag back to true.
+ *
+ * Run:  node --env-file=.env.local scripts/curate-skills.mjs
+ */
+import { createClient } from '@sanity/client'
+
+const token = process.env.SANITY_API_WRITE_TOKEN
+if (!token) {
+  console.error('✗ SANITY_API_WRITE_TOKEN missing — run with: node --env-file=.env.local scripts/curate-skills.mjs')
+  process.exit(1)
+}
+
+const client = createClient({
+  projectId: '79vh6zyc',
+  dataset: 'production',
+  apiVersion: '2023-11-30',
+  token,
+  useCdn: false
+})
+
+// Skills to keep as technology tags but hide from the Skills grid
+// (resume-aligned trim, approved 2026-07-07).
+const hideIds = [
+  '0866e202-6221-4571-a9a1-9b09b5d432d6', // DB2
+  '2d546bb5-5ce7-47e5-a790-6c818207fa93', // Oxylabs web scrape
+  '32f5a9f5-1a51-4698-8018-4c3fbc68f793', // Sanity IO
+  '330e811e-3c45-4a59-9e01-bec7d2cae0f6', // Firebase
+  '380c0079-6f85-4e8b-978c-e1de041f602c', // Material UI
+  '49dc3c24-675b-410c-9299-e06f23385930', // Mainframe
+  '4d963f80-cbb6-4d7b-a623-093bba2e62d1', // App write cloud
+  '54dfb41c-bb44-4942-97cc-9499bcaccd60', // Stepzen
+  '77af1cf6-a36c-46c5-870b-5c92d8acd500', // Dropzone
+  '7b3af20f-a9e8-466e-ac92-86ec8f08e1fc', // Azure functions
+  '83efae6b-0d39-413d-8286-083a3f0c0c11', // i18next
+  'badeacb6-9d1d-4333-a0c4-a667ef55f65b', // SWR
+  'c764f68c-6121-4b6e-bb63-da12ff9499e5', // COBOL
+  'ccc2c062-98d5-4e40-ad1a-e4b309171c0c', // Open AI API
+  'de11c551-0bd0-4c4e-9ca2-ddd4842b9aa2', // Chart JS
+  'e6d911cc-c3e5-4491-a7e8-8998b267441a', // ShadCn UI
+  'f77f3f90-68ea-489d-b968-2de44724247f' //  Clerk
+]
+
+let tx = client.transaction()
+for (const id of hideIds) {
+  tx = tx.patch(id, patch => patch.set({ showInSkills: false }))
+}
+
+const result = await tx.commit()
+console.log(`✓ committed ${result.transactionId}: ${hideIds.length} skills hidden from the grid (documents retained as tech tags)`)

--- a/scripts/fetch-content.mjs
+++ b/scripts/fetch-content.mjs
@@ -24,7 +24,7 @@ const client = createClient({
 const queries = {
   pageInfo: '*[_type == "pageInfo"][0]',
   experiences: '*[_type == "experience"] { ..., technologies[]-> }',
-  skills: '*[_type == "skill"]',
+  skills: '*[_type == "skill" && showInSkills != false]',
   projects: '*[_type == "project"] { ..., technologies[]-> }',
   socials: '*[_type == "social"]'
 }

--- a/scripts/fetch-content.mjs
+++ b/scripts/fetch-content.mjs
@@ -17,7 +17,8 @@ const client = createClient({
   projectId: process.env.SANITY_PROJECT_ID || '79vh6zyc',
   dataset: process.env.SANITY_DATASET || 'production',
   apiVersion: '2023-11-30',
-  useCdn: true
+  // no CDN: build-time snapshots must always see the latest published content
+  useCdn: false
 })
 
 const queries = {

--- a/scripts/seed-resume-content.mjs
+++ b/scripts/seed-resume-content.mjs
@@ -1,0 +1,159 @@
+/**
+ * One-off content seed: updates Sanity documents to match the July 2026
+ * resume (Senior React.js Developer). Source of truth: resume.md (local).
+ *
+ * Run:  node --env-file=.env.local scripts/seed-resume-content.mjs
+ * Requires SANITY_API_WRITE_TOKEN (Editor) in .env.local.
+ *
+ * Idempotent: creates use createOrReplace with deterministic _ids,
+ * updates are patch.set operations.
+ *
+ * Image assets were uploaded beforehand (asset _ids below):
+ * WPP Open logo provided by Nayeem; skill icons from Devicon/Simple Icons/
+ * GitHub org avatars.
+ */
+import { createClient } from '@sanity/client'
+
+const token = process.env.SANITY_API_WRITE_TOKEN
+if (!token) {
+  console.error('✗ SANITY_API_WRITE_TOKEN missing — run with: node --env-file=.env.local scripts/seed-resume-content.mjs')
+  process.exit(1)
+}
+
+const client = createClient({
+  projectId: '79vh6zyc',
+  dataset: 'production',
+  apiVersion: '2023-11-30',
+  token,
+  useCdn: false
+})
+
+const imageRef = ref => ({ _type: 'image', asset: { _type: 'reference', _ref: ref } })
+const skillRef = id => ({ _type: 'reference', _ref: id, _key: `k-${id.slice(0, 12)}` })
+
+// ---------------------------------------------------------------- new skills
+const newSkills = [
+  { _id: 'skill-stenciljs', title: 'StencilJS', progress: 50, asset: 'image-dc51f48670b949b9d2a743ec8fd9a83eff2f9173-24x24-svg' },
+  { _id: 'skill-storybook', title: 'Storybook', progress: 50, asset: 'image-d0ca32b76cc723b78fdd4b429b7e797ed3561276-24x24-svg' },
+  { _id: 'skill-playwright', title: 'Playwright', progress: 45, asset: 'image-f6430a83fc9990d711ed927ffeef0a51a63f00e6-128x128-svg' },
+  { _id: 'skill-axe-core', title: 'axe-core', progress: 45, asset: 'image-7ed43bb55b81e849d4bc8eec0fddb3716e5a3d19-200x200-png' },
+  { _id: 'skill-scss', title: 'SCSS', progress: 55, asset: 'image-eab315098699440d235d2851513ff6b57a5de81a-128x128-svg' },
+  { _id: 'skill-github-actions', title: 'GitHub Actions', progress: 40, asset: 'image-3b6c32b275f29e488047db0de512729f625bf7a8-128x128-svg' },
+  { _id: 'skill-webpack', title: 'Webpack', progress: 40, asset: 'image-86aac2a3bac7b201fb6791af0161231f3ce6ee3e-128x128-svg' },
+  { _id: 'skill-ag-grid', title: 'AG Grid', progress: 35, asset: 'image-64ea4dada74cef102541b2008d2e1f9b68dbf766-200x200-png' }
+]
+
+// existing skill _ids referenced by the WPP experience
+const EXISTING = {
+  reactJs: '188e9d55-15ad-40b7-872a-1b6be1b24410',
+  typescript: 'c04fc355-3b3a-46b3-8b65-c370e337ccac',
+  jest: 'd6c43ddf-0518-441c-b7b0-5df4476f6954'
+}
+
+// ------------------------------------------------------------ WPP experience
+const wppExperience = {
+  _id: 'experience-wpp-2024',
+  _type: 'experience',
+  jobId: 9,
+  jobTitle: 'Senior Frontend Engineer',
+  company: 'WPP',
+  companyImage: imageRef('image-9c0b59a6d8ba2ba8edb825ffdbf0e7e81c5e27ad-800x800-png'),
+  dateStarted: '2024-03-01',
+  isCurrentlyWorkingHere: true,
+  technologies: [
+    skillRef('skill-stenciljs'),
+    skillRef(EXISTING.reactJs),
+    skillRef(EXISTING.typescript),
+    skillRef('skill-scss'),
+    skillRef('skill-storybook'),
+    skillRef(EXISTING.jest),
+    skillRef('skill-playwright'),
+    skillRef('skill-axe-core'),
+    skillRef('skill-github-actions')
+  ],
+  points: [
+    "Core contributor to WPP Open's design system — a monorepo of 76+ reusable web components with React, Vue, and Angular bindings, used by product teams across the company.",
+    "Own the design system's WCAG 2.1 AA accessibility programme: built an automated audit pipeline (Playwright + axe-core) scanning 165 Storybook stories across 76 components against 50 WCAG criteria, and produced conformance evidence used in a UK Government preliminary assessment.",
+    'Remediated key components (datepicker, time-picker, search, breadcrumb, chat) to zero serious/critical accessibility violations, implementing W3C ARIA APG keyboard patterns (combobox, treeview, tabs, menu).',
+    'Led the rich-text editor migration from Quill.js to Tiptap v3 — the library’s largest single feature — including full migration guides and backward-compatible APIs.',
+    'Drove major-version (v4) release preparation: removed 17+ deprecated APIs, resolved npm security vulnerabilities to a clean audit state, and kept 1,700+ unit tests green across 109 suites.',
+    'Conduct regular code reviews and mentor the team through reusable engineering playbooks and coding standards; support consuming teams as a design-system point of contact.'
+  ]
+}
+
+// --------------------------------------------------------------- patches
+const patches = [
+  {
+    id: '9c6b7c47-d81b-4f4d-a81e-1e357a1479e3', // pageInfo
+    set: {
+      role: 'Senior React.js Developer',
+      backgroundInformation:
+        "Senior front-end engineer with 15 years in software development, the last 8+ focused on React.js. Currently a core contributor to WPP's enterprise design system, where I build and maintain a library of 76+ reusable, high-performance UI components consumed by React, Vue, and Angular applications company-wide. I define front-end architecture and coding standards, lead accessibility (WCAG 2.1 AA) and performance programmes, conduct rigorous code reviews, and mentor engineers through review feedback and reusable playbooks. Strong track record of shipping complex migrations (rich-text editor, major-version API cleanups) and building automated testing infrastructure (Jest, Playwright, axe-core)."
+    }
+  },
+  {
+    id: '0587916a-edfe-427c-af06-d064216cc505', // Planet
+    set: {
+      company: 'Planet Payment',
+      dateStarted: '2023-03-01',
+      dateEnded: '2023-12-31',
+      isCurrentlyWorkingHere: false,
+      points: [
+        'Built data-driven business applications for a global integrated payments platform (acquiring, processing, digital wallets, VAT refund, currency conversion).',
+        'Wrote high-quality, cross-platform TypeScript/HTML/CSS with a focus on fluid navigation and accessibility optimisation.',
+        'Reviewed product requirements to provide development estimates and product feedback.'
+      ]
+    }
+  },
+  {
+    id: '190d3cf0-460b-464e-970d-efa831ee0cd4', // Preqin
+    set: {
+      points: [
+        'Designed and implemented user-facing features on pro.preqin.com — investor and fund-manager profile contacts data transformation, plus subscription-package restrictions across all users.',
+        'Built reusable components and front-end libraries; reviewed code and provided feedback to raise codebase quality.'
+      ]
+    }
+  },
+  {
+    id: '3775834b-ac4d-4f1a-82d5-1c9f7ff82f16', // Wipro
+    set: {
+      points: [
+        'Led front-end delivery for Santander Bank US — a consumer web application for banking products.',
+        'Translated Figma designs into reusable, efficient UI components; coordinated across QA, server, design, and product teams.'
+      ]
+    }
+  },
+  {
+    id: '1e98c9ec-c284-47e8-bc4f-e6a4b349fb8a', // ITC Infotech
+    set: {
+      points: [
+        'Developed end-user insurance applications for RSA (Royal Sun & Alliance, UK) — requirement study, planning, and development.'
+      ]
+    }
+  },
+  {
+    id: 'e4fb3f32-d859-4594-af7c-f0d229b6e6f6', // Meredith
+    set: {
+      points: [
+        'Front-end development for digital media properties; began the transition into the React ecosystem.'
+      ]
+    }
+  },
+  {
+    id: '37d588d8-5abf-48e2-b8c2-96b5c98e753a', // Infosys — fix bad end date (was 2017, overlapping later roles)
+    set: { dateEnded: '2014-07-18' }
+  }
+]
+
+// ----------------------------------------------------------------- execute
+let tx = client.transaction()
+for (const s of newSkills) {
+  tx = tx.createOrReplace({ _id: s._id, _type: 'skill', title: s.title, progress: s.progress, image: imageRef(s.asset) })
+}
+tx = tx.createOrReplace(wppExperience)
+for (const p of patches) {
+  tx = tx.patch(p.id, patch => patch.set(p.set))
+}
+
+const result = await tx.commit()
+console.log(`✓ committed transaction ${result.transactionId}: ${newSkills.length} skills + WPP experience upserted, ${patches.length} documents patched`)


### PR DESCRIPTION
## PR 6 — `feat/resume-content-update` (Goal 5)

All Sanity mutations **already executed** (per your approvals). This PR carries the seed/curation scripts for the audit trail plus the schema/query changes that back them.

### Experience & summary (from resume.md)
- **pageInfo**: role → **Senior React.js Developer**; background → resume professional summary
- **NEW: Senior Frontend Engineer @ WPP** (Mar 2024 – Present) — first card, your WPP Open logo, 6 bullets, 9 tech icons
- **Planet** corrected from 'Present' → **Mar 2023 – Dec 2023** ('Planet Payment'), 3 bullets
- **Preqin / Wipro / ITC / Meredith**: bullets replaced with resume text
- **Infosys dateEnded** fixed 2017 → **Jul 2014** (was overlapping 3 later jobs)
- Projects untouched (kept all 10, per your call)

### Skills grid curation (41 → 24)
The skill docs double as **technology tags** on experience/project cards, so the 17 removed-from-grid skills couldn't be deleted without breaking card icons. Instead:
- added a **`showInSkills`** boolean to the skill schema (defaults true)
- grid query now filters `showInSkills != false`
- `scripts/curate-skills.mjs` hides the 17 (jokes: COBOL/Mainframe/DB2; project-glue: Oxylabs/Dropzone/Stepzen/Appwrite/Azure/Clerk/SWR/OpenAI/Firebase/ChartJS/MaterialUI/ShadCn/i18next/Sanity)

**Result:** grid shows 24 focused skills; **every experience/project card keeps its tech icons (0 broken refs verified).** Fully reversible by flipping the flag.

### 8 new skills added to grid
StencilJS, Storybook, Playwright, axe-core, SCSS, GitHub Actions, Webpack, AG Grid (with icons).

### Build-fetch fix
`fetch-content.mjs` → `useCdn: false` (CDN served stale results right after mutations; build snapshots must see latest published content).

### Verification
- Both seed transactions committed cleanly; idempotent
- Content re-fetched, site rebuilt, visually verified: WPP card first w/ logo, hero shows 'SENIOR REACT.JS DEVELOPER', 24-icon skills grid, card tech icons intact
- `npm run build` + `npm run lint` green ✅
- **Live production already reflects the content** (I redeployed `main`; bundle contains WPP/Planet Payment strings)

### Revert
`git revert` removes the scripts + schema/query changes; content itself reversible by re-running with prior values (recorded) — ask for a rollback script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)