### PR TITLE
chore: a11y & SEO polish (headings, link name, favicon, robots)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Nayeem's Portfolio</title>
     <meta
       name="description"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#242424" />
+  <text x="32" y="33" font-family="Consolas, 'Cascadia Mono', monospace" font-size="34" font-weight="700"
+        fill="#D92815" text-anchor="middle" dominant-baseline="central">N</text>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
         <ContactMe pageInfo={pageInfo} />
       </section>
 
-      <a href='#hero'>
+      <a href='#hero' aria-label='Back to top'>
         <footer className='sticky bottom-px w-full cursor-pointer md:bottom-5'>
           <div className='flex items-center justify-center'>
             <ChevronDoubleUpIcon className='h-7 w-7 cursor-pointer rounded-full text-gray-500 transition-colors duration-200 hover:text-sun md:h-10 md:w-10' />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -12,7 +12,7 @@ const About = ({ pageInfo }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-center px-10 text-center md:flex-row md:justify-evenly md:text-left'>
-      <h3 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>About</h3>
+      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>About</h2>
 
       <motion.img
         src={urlFor(pageInfo?.profilePic).url()}
@@ -25,9 +25,9 @@ const About = ({ pageInfo }: Props) => {
       />
 
       <div className='max-sm:max-h-[500px] space-y-4 px-0 md:space-y-10 md:px-10'>
-        <h4 className='text-4xl font-semibold'>
+        <h3 className='text-4xl font-semibold'>
           Here is a <span className='underline decoration-sun underline-offset-4'>little</span> background
-        </h4>
+        </h3>
 
         <p className='text-balance overflow-y-scrollbar-track-gray-400/20 max-sm:max-h-[450px] overflow-y-auto text-sm scrollbar-thin scrollbar-thumb-sun/80'>
           {pageInfo?.backgroundInformation}

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -25,42 +25,40 @@ const ContactMe = ({ pageInfo }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative z-0 mx-auto flex h-screen max-w-7xl flex-col items-center justify-evenly px-10 text-center md:flex-row md:text-left'>
-      <h3 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Contact Me</h3>
+      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Contact Me</h2>
 
       <div className='flex flex-col space-y-5'>
-        <h4 className='text-center text-[min(4vw, 200px)] text-balance font-semibold'>
+        <h3 className='text-balance text-center font-semibold'>
           I have got just the right skills to help you with your project.{' '}
           <span className='underline decoration-sun/50 underline-offset-4'>Let&apos;s talk!</span>
-        </h4>
+        </h3>
 
         <div className='space-y-3'>
           <div className='flex items-center justify-center space-x-3'>
             <PhoneIcon className='h-7 w-7 animate-pulse text-sun' />
-            <p className='text-[min(3vw, 100px)]'>{pageInfo.phoneNumber}</p>
+            <p>{pageInfo.phoneNumber}</p>
           </div>
 
           <div className='flex items-center justify-center space-x-3'>
             <EnvelopeIcon className='h-7 w-7 animate-pulse text-sun' />
-            <a className='text-[min(3vw, 100px)]' href={`mailto:${pageInfo.email}`}>
-              {pageInfo.email}
-            </a>
+            <a href={`mailto:${pageInfo.email}`}>{pageInfo.email}</a>
           </div>
 
           <div className='flex items-center justify-center space-x-3'>
             <MapPinIcon className='h-7 w-7 animate-pulse text-sun' />
-            <p className='text-[min(3vw, 100px)]'>{pageInfo.address}</p>
+            <p>{pageInfo.address}</p>
           </div>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)} className='mx-auto flex w-[95%] md:w-fit flex-col space-y-2'>
           <div className='flex space-x-2'>
-            <input {...register('name')} className='contactInput text-[min(2vw, 75px)] w-[95%]' type='text' placeholder='Name' />
-            <input {...register('email')} className='contactInput text-[min(2vw, 75px)] w-[95%]' type='email' placeholder='Email' />
+            <input {...register('name')} className='contactInput w-[95%]' type='text' placeholder='Name' />
+            <input {...register('email')} className='contactInput w-[95%]' type='email' placeholder='Email' />
           </div>
 
-          <input {...register('subject')} className='contactInput text-[min(2vw, 75px)]' type='text' placeholder='Subject' />
+          <input {...register('subject')} className='contactInput' type='text' placeholder='Subject' />
 
-          <textarea {...register('message')} className='contactInput text-[min(2vw, 75px)]' placeholder='Message' />
+          <textarea {...register('message')} className='contactInput' placeholder='Message' />
 
           <button className='text-black rounded-md bg-sun px-5 py-3 md:px-10 md:py-5 text-lg font-bold' type='submit'>
             Submit

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -23,7 +23,7 @@ const ExperienceCard = ({ experience }: Props) => {
             className='h-20 w-20 rounded-full object-cover object-center md:h-32 md:w-32 xl:h-[150px] xl:w-[150px]'
           />
           <div>
-            <h4 className='text-xs font-light md:text-2xl'>{experience.jobTitle}</h4>
+            <h3 className='text-xs font-light md:text-2xl'>{experience.jobTitle}</h3>
             <p className='mt-1 text-base font-bold md:text-3xl'>{experience.company}</p>
             <p className='py-2 text-xs uppercase text-gray-300 md:py-3 xl:py-5'>
               {new Date(experience.dateStarted).toDateString()} -{' '}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -24,7 +24,7 @@ const Hero = ({ pageInfo }: Props) => {
       />
 
       <div className='z-20'>
-        <h2 className='text-xs uppercase tracking-[15px] text-gray-500 md:text-sm'>{pageInfo?.role}</h2>
+        <p className='text-xs uppercase tracking-[15px] text-gray-500 md:text-sm'>{pageInfo?.role}</p>
 
         <h1 className='h-[20px] p-10 text-2xl font-semibold text-white md:text-5xl lg:text-6xl'>
           <span className='mr-3 font-mono'>{text}</span>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -12,7 +12,7 @@ const Projects = ({ projects }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative z-0 mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden text-left md:flex-row'>
-      <h3 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Projects</h3>
+      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Projects</h2>
 
       <div className='relative z-20 flex w-full snap-x snap-mandatory overflow-y-hidden overflow-x-auto scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun'>
         {projects
@@ -32,12 +32,12 @@ const Projects = ({ projects }: Props) => {
               />
 
               <div className='max-w-6xl space-y-3 px-0 md:space-y-5 md:px-10'>
-                <h4 className='text-1xl text-center font-semibold'>
+                <h3 className='text-1xl text-center font-semibold'>
                   <span className='underline decoration-sun underline-offset-4'>
                     Project {project.projectId} of {projects.length}:
                   </span>{' '}
                   {project.title}
-                </h4>
+                </h3>
 
                 {project?.technologies?.length > 0 && (
                   <div className='flex items-center justify-center space-x-2'>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -14,7 +14,7 @@ const Skills = ({ skills }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center text-center md:text-left xl:flex-row xl:space-y-0 xl:px-10'>
-      <h3 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Skills</h3>
+      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Skills</h2>
 
       <h3 className='absolute top-36 uppercase tracking-[3px]'>Hover over a skill for current proficiency</h3>
 

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -12,7 +12,7 @@ const WorkExperience = ({ experiences }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden md:px-10 text-left md:flex-row'>
-      <h3 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Experience</h3>
+      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Experience</h2>
       <div className='flex w-full snap-x snap-mandatory space-x-5 overflow-x-auto p-10 scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun/80'>
         {experiences
           ?.sort((a, b) => b.jobId - a.jobId)


### PR DESCRIPTION
## PR 10 — `chore/a11y-seo-polish` (Goal 7, part 1 of 2)

The no-dependency, no-visual-change half of Goal 7. **The design is untouched** — heading tags change but their classNames (all styling) don't, and the removed classes were already dead.

### Changes
- **Heading hierarchy** → valid `h1 → h2 → h3` (Lighthouse *heading-order* now passes): hero role `h2`→`p` (eyebrow label, not a heading); section titles `h3`→`h2`; job/project/sub titles `h4`→`h3`
- **Footer scroll-to-top** link gets `aria-label="Back to top"` (was unnamed → failed *link-name*)
- **Favicon**: `public/favicon.svg` (dark tile + sun-red "N") + `<link>` — removes the `/favicon.ico` **404 console error**
- **`public/robots.txt`** added
- **ContactMe cleanup**: removed dead `text-[min(…, …)]` classes (the internal space meant Tailwind never generated them → removal is visually a no-op)

### Lighthouse (local preview, baseline → this PR)
Accessibility **87 → 92**, Best-practices **92 → 96**, SEO **92 → 100**, Performance 75 → 75 (perf is part 2).

### Verified
Heading order valid (measured), favicon + robots serve 200, hero/contact visually unchanged; build/lint/tsc green.

### Deferred to part 2 (`perf/responsiveness`)
Color contrast (muted gray-500 fails 4.5:1 — fixing lightens the brand, so I'll flag it for your call) and touch-target size, plus the mobile header fix, react-social-icons replacement, lazy-loading, image sizing, and before/after perf numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)