### PR TITLE
perf: optimize images & fix mobile responsiveness (Lighthouse perf 75→90)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://cdn.sanity.io" crossorigin />
     <title>Nayeem's Portfolio</title>
     <meta
       name="description"

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react'
 
-import { urlFor } from '../lib/sanity'
+import { imageSrc } from '../lib/sanity'
 import type { PageInfo } from '../types'
 
 type Props = { pageInfo: PageInfo }
@@ -15,12 +15,14 @@ const About = ({ pageInfo }: Props) => {
       <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>About</h2>
 
       <motion.img
-        src={urlFor(pageInfo?.profilePic).url()}
+        src={pageInfo?.profilePic && imageSrc(pageInfo.profilePic, 640)}
         initial={{ x: -200, opacity: 0 }}
         transition={{ duration: 1.2 }}
         whileInView={{ x: 0, opacity: 1 }}
         viewport={{ once: true }}
         alt='Profile picture'
+        loading='lazy'
+        decoding='async'
         className='mb-3 h-44 w-44 shrink-0 rounded-full object-cover md:mb-0 md:h-96 md:w-64 md:rounded-lg xl:h-[600px] xl:w-[500px]'
       />
 

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react'
 
-import { urlFor } from '../lib/sanity'
+import { imageSrc } from '../lib/sanity'
 import type { Experience } from '../types'
 
 type Props = { experience: Experience }
@@ -18,8 +18,10 @@ const ExperienceCard = ({ experience }: Props) => {
             transition={{ duration: 1.2 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            src={urlFor(experience.companyImage).url()}
+            src={imageSrc(experience.companyImage, 300)}
             alt={experience.company}
+            loading='lazy'
+            decoding='async'
             className='h-20 w-20 rounded-full object-cover object-center md:h-32 md:w-32 xl:h-[150px] xl:w-[150px]'
           />
           <div>
@@ -36,9 +38,11 @@ const ExperienceCard = ({ experience }: Props) => {
           {experience.technologies.map(technology => (
             <img
               key={technology._id}
-              className='h-4 w-4 rounded-full md:h-8 md:w-8'
-              src={urlFor(technology.image).url()}
+              className='h-4 w-4 rounded-full object-cover md:h-8 md:w-8'
+              src={imageSrc(technology.image, 64)}
               alt={technology.title}
+              loading='lazy'
+              decoding='async'
             />
           ))}
         </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import { Cursor, useTypewriter } from 'react-simple-typewriter'
 
-import { urlFor } from '../lib/sanity'
+import { imageSrc } from '../lib/sanity'
 import type { PageInfo } from '../types'
 import BackgroundCircles from './BackgroundCircles'
 
@@ -18,9 +18,12 @@ const Hero = ({ pageInfo }: Props) => {
       <BackgroundCircles />
 
       <img
-        src={urlFor(pageInfo?.heroImage).url()}
+        src={pageInfo?.heroImage && imageSrc(pageInfo.heroImage, 256)}
         className='relative mx-auto h-32 w-32 rounded-full object-cover'
         alt='Profile picture'
+        width={128}
+        height={128}
+        fetchPriority='high'
       />
 
       <div className='z-20'>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react'
 
-import { urlFor } from '../lib/sanity'
+import { imageSrc } from '../lib/sanity'
 import type { Project } from '../types'
 
 type Props = { projects: Project[] }
@@ -26,9 +26,11 @@ const Projects = ({ projects }: Props) => {
                 transition={{ duration: 1.2 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                src={urlFor(project?.image).url()}
+                src={project?.image && imageSrc(project.image, 800)}
                 className='h-[250px] w-[350px] rounded-xl object-cover shadow-xl md:h-[350px] md:w-[500px]'
                 alt={project.title}
+                loading='lazy'
+                decoding='async'
               />
 
               <div className='max-w-6xl space-y-3 px-0 md:space-y-5 md:px-10'>
@@ -44,9 +46,11 @@ const Projects = ({ projects }: Props) => {
                     {project.technologies.map(technology => (
                       <img
                         key={technology._id}
-                        className='h-6 w-6 rounded-full md:h-10 md:w-10'
-                        src={urlFor(technology.image).url()}
+                        className='h-6 w-6 rounded-full object-cover md:h-10 md:w-10'
+                        src={imageSrc(technology.image, 80)}
                         alt={technology.title}
+                        loading='lazy'
+                        decoding='async'
                       />
                     ))}
                   </div>

--- a/src/components/ResumeDownload.tsx
+++ b/src/components/ResumeDownload.tsx
@@ -36,9 +36,9 @@ const ResumeDownload = () => {
   return (
     <details ref={ref} className='group relative'>
       <summary
-        className='flex cursor-pointer list-none items-center gap-1.5 text-sm uppercase text-gray-400 transition-colors duration-200 hover:text-sun [&::-webkit-details-marker]:hidden'
+        className='flex min-h-6 cursor-pointer list-none items-center gap-1.5 text-sm uppercase text-gray-400 transition-colors duration-200 hover:text-sun [&::-webkit-details-marker]:hidden'
         aria-label='Download résumé'>
-        <ArrowDownTrayIcon className='h-5 w-5' />
+        <ArrowDownTrayIcon className='h-6 w-6' />
         <span className='hidden md:inline'>Résumé</span>
       </summary>
 

--- a/src/components/Skill.tsx
+++ b/src/components/Skill.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react'
 
-import { urlFor } from '../lib/sanity'
+import { imageSrc } from '../lib/sanity'
 import type { Skill as SkillType } from '../types'
 
 type Props = {
@@ -13,8 +13,10 @@ const Skill = ({ skill, directionLeft }: Props) => {
     <div className='group relative flex cursor-pointer'>
       <motion.img
         className='rounded-full object-cover w-14 h-14 md:w-18 md:h-18 lg:w-20 lg:h-20 xl:h-24 xl:w-24 filter group-hover:grayscale transition duration-300 ease-in-out'
-        src={urlFor(skill.image).url()}
+        src={imageSrc(skill.image, 200)}
         alt={skill.title}
+        loading='lazy'
+        decoding='async'
         initial={{ x: directionLeft ? -200 : 200, opacity: 0 }}
         whileInView={{ opacity: 1, x: 0 }}
         transition={{ duration: 1 }}

--- a/src/index.css
+++ b/src/index.css
@@ -59,3 +59,15 @@
     font-family: 'Inter Variable', sans-serif;
   }
 }
+
+/*
+  react-social-icons renders fixed 50px anchors. On small phones the header's
+  7 social icons plus the résumé/contact actions overflow the viewport and
+  clip off-screen, so shrink them below the sm breakpoint. Desktop is unchanged.
+*/
+@media (max-width: 639px) {
+  header .social-icon {
+    height: 1.875rem !important;
+    width: 1.875rem !important;
+  }
+}

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -12,3 +12,12 @@ const builder = createImageUrlBuilder({
 })
 
 export const urlFor = (source: SanityImage) => builder.image(source)
+
+/**
+ * Builds an optimized image URL sized for display: capped width, quality 80,
+ * and auto WebP/AVIF. The source images in Sanity are multi-megabyte full-res,
+ * so requesting a display-sized rendition is the single biggest perf win.
+ * Pass the intended CSS display width; use ~2x for retina crispness.
+ */
+export const imageSrc = (source: SanityImage, width: number) =>
+  builder.image(source).width(width).quality(80).auto('format').url()


### PR DESCRIPTION
## PR 11 — `perf/responsiveness` (Goal 7, part 2 of 2 — final PR)

### The headline: 17.7 MB → 571 KB
Your Sanity images were served at **full resolution** — the three heaviest were **3.7 MB, 3.5 MB, and 1.7 MB** — to display at 40–500 px. That single issue caused the 7-second LCP.

- **`imageSrc()` helper**: requests display-sized, quality-80, auto **WebP/AVIF** renditions. Every image now asks for ~2× its CSS size instead of full-res.
- **Lazy-loading**: `loading="lazy"` + `decoding="async"` on all below-fold images; the hero image stays eager with `fetchpriority="high"` (it's the LCP element).
- **Preconnect** to `cdn.sanity.io`.
- **`object-cover`** on the experience/project tech icons (fixes *image-aspect-ratio*).

### Mobile responsiveness
- **Header overflow fixed**: at ≤360 px the 7 social icons pushed the résumé + contact controls off-screen (clipped at 320 px). Social icons now shrink below the `sm` breakpoint so everything fits down to 320 px. **Desktop icons unchanged (50 px).**
- **Résumé trigger** enlarged to a 24 px min touch target (*target-size*).

### Lighthouse (local preview, baseline → now)
| | Before | After |
|---|---|---|
| **Performance** | 75 | **90** |
| **Accessibility** | 87 | **96** |
| **Best-practices** | 92 | **100** |
| **SEO** | 92 | **100** |
| LCP | 7.0 s | **3.2 s** |
| Page weight | 17,741 KiB | **571 KiB** |

### On the remaining 4 a11y points
The only failing a11y audit is **color-contrast** — the muted `gray-500` text you asked to keep as-is. With that fix a11y would be 100, but we agreed to preserve the brand's muted look. Documented as an intentional exception.

### Verified
- Images requesting `w=…&q=80&auto=format` (measured); 165/166 lazy, hero eager+high ✅
- 320 px header: résumé control **visible** (was clipped), 24 px tap target, no horizontal overflow ✅
- Desktop icons 50 px (unchanged), About/hero images **crisp** — no quality loss (screenshots) ✅
- `npm run build` / `lint` / `tsc` green ✅

### Optional future win (not done — would change icon glyphs)
Replacing `react-social-icons` (412 KB) with inline SVGs would trim ~55 KB of unused JS, but it renders slightly different glyphs, so I left it out to preserve the exact current icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)