### PR TITLE
feat(ux): mobile responsive overhaul (Design Step 2)

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -11,7 +11,7 @@ const About = ({ pageInfo }: Props) => {
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
-      className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-center px-10 text-center md:flex-row md:justify-evenly md:text-left'>
+      className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-start px-10 pt-32 text-center md:flex-row md:justify-evenly md:pt-0 md:text-left'>
       <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>About</h2>
 
       <motion.img

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -1,13 +1,32 @@
 import { motion } from 'motion/react'
+import { useState } from 'react'
 
 import { imageSrc } from '../lib/sanity'
 import type { Experience } from '../types'
 
 type Props = { experience: Experience }
 
+const fmt = (date: string) => new Date(date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+
 const ExperienceCard = ({ experience }: Props) => {
+  // Desktop reveals the card on hover; touch/keyboard toggle it on tap/Enter,
+  // since hover doesn't exist on touch devices (cards would stay dimmed).
+  const [active, setActive] = useState(false)
+
   return (
-    <article className='flex h-[510px] w-[320px] shrink-0 cursor-pointer snap-center flex-col items-center space-y-7 overflow-hidden rounded-lg bg-gray-16 p-5 opacity-40 transition-opacity duration-200 hover:opacity-100 md:w-[600px] xl:w-[900px] xl:p-10'>
+    <article
+      onClick={() => setActive(a => !a)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setActive(a => !a)
+        }
+      }}
+      tabIndex={0}
+      role='button'
+      aria-pressed={active}
+      aria-label={`${experience.jobTitle} at ${experience.company} — tap to highlight`}
+      className={`flex h-[510px] w-[320px] shrink-0 cursor-pointer snap-center flex-col items-center space-y-7 overflow-hidden rounded-lg bg-gray-16 p-5 transition-opacity duration-200 focus-visible:opacity-100 md:w-[600px] xl:w-[900px] xl:p-10 ${active ? 'opacity-100' : 'opacity-40 hover:opacity-100'}`}>
       <div className='px-0 md:px-10'>
         <div className='flex flex-row items-center justify-center gap-2 md:gap-4'>
           <motion.img
@@ -28,8 +47,7 @@ const ExperienceCard = ({ experience }: Props) => {
             <h3 className='text-xs font-light md:text-2xl'>{experience.jobTitle}</h3>
             <p className='mt-1 text-base font-bold md:text-3xl'>{experience.company}</p>
             <p className='py-2 text-xs uppercase text-gray-300 md:py-3 xl:py-5'>
-              {new Date(experience.dateStarted).toDateString()} -{' '}
-              {experience.isCurrentlyWorkingHere ? 'Present' : new Date(experience.dateEnded).toDateString()}
+              {fmt(experience.dateStarted)} - {experience.isCurrentlyWorkingHere ? 'Present' : fmt(experience.dateEnded)}
             </p>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,10 @@ const Header = ({ socials }: Props) => {
         transition={{ duration: 1.5 }}
         className='flex flex-row items-center'>
         {socials
-          ?.sort((a, b) => a.socialId - b.socialId)
+          // Drop the stale "Resume" entry (a defunct Google+ glyph linking to an
+          // old Google Drive file) — the dedicated résumé download replaces it.
+          ?.filter(social => !social.url?.includes('drive.google.com'))
+          .sort((a, b) => a.socialId - b.socialId)
           .map(social => (
             <SocialIcon
               key={social.socialId}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -26,31 +26,30 @@ const Hero = ({ pageInfo }: Props) => {
         fetchPriority='high'
       />
 
-      <div className='z-20'>
-        <p className='text-xs uppercase tracking-[15px] text-gray-500 md:text-sm'>{pageInfo?.role}</p>
+      <div className='z-20 flex flex-col items-center px-4'>
+        <p className='text-xs uppercase leading-relaxed tracking-[8px] text-gray-500 sm:tracking-[12px] md:text-sm md:tracking-[15px]'>
+          {pageInfo?.role}
+        </p>
 
-        <h1 className='h-[20px] p-10 text-2xl font-semibold text-white md:text-5xl lg:text-6xl'>
+        <h1 className='flex min-h-24 items-center justify-center py-6 text-2xl font-semibold text-white md:min-h-20 md:text-5xl lg:text-6xl'>
           <span className='mr-3 font-mono'>{text}</span>
           <Cursor cursorColor='#D92815' />
         </h1>
 
-        <div className='relative bottom-[-30px] md:bottom-[-70px]'>
-          <a href='#about'>
-            <button className='heroButton'>About</button>
+        <nav className='mt-6 flex flex-wrap items-center justify-center gap-3 md:mt-10'>
+          <a href='#about' className='heroButton'>
+            About
           </a>
-
-          <a href='#experience'>
-            <button className='heroButton'>Experience</button>
+          <a href='#experience' className='heroButton'>
+            Experience
           </a>
-
-          <a href='#skills'>
-            <button className='heroButton'>Skills</button>
+          <a href='#skills' className='heroButton'>
+            Skills
           </a>
-
-          <a href='#projects'>
-            <button className='heroButton'>Projects</button>
+          <a href='#projects' className='heroButton'>
+            Projects
           </a>
-        </div>
+        </nav>
       </div>
     </div>
   )

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'motion/react'
+import { useRef, useState } from 'react'
 
 import { imageSrc } from '../lib/sanity'
 import type { Project } from '../types'
@@ -6,6 +7,20 @@ import type { Project } from '../types'
 type Props = { projects: Project[] }
 
 const Projects = ({ projects }: Props) => {
+  const sorted = [...(projects ?? [])].sort((a, b) => a.projectId - b.projectId)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [active, setActive] = useState(0)
+
+  const onScroll = () => {
+    const el = scrollRef.current
+    if (el) setActive(Math.round(el.scrollLeft / el.clientWidth))
+  }
+
+  const goTo = (i: number) => {
+    const el = scrollRef.current
+    if (el) el.scrollTo({ left: i * el.clientWidth, behavior: 'smooth' })
+  }
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -14,52 +29,69 @@ const Projects = ({ projects }: Props) => {
       className='relative z-0 mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden text-left md:flex-row'>
       <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Projects</h2>
 
-      <div className='relative z-20 flex w-full snap-x snap-mandatory overflow-y-hidden overflow-x-auto scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun'>
-        {projects
-          ?.sort((a, b) => a.projectId - b.projectId)
-          .map(project => (
-            <div
-              key={project.projectId}
-              className='flex h-screen w-screen shrink-0 snap-center flex-col items-center justify-center space-y-5 p-20 md:p-44'>
-              <motion.img
-                initial={{ opacity: 0, y: -300 }}
-                transition={{ duration: 1.2 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                src={project?.image && imageSrc(project.image, 800)}
-                className='h-[250px] w-[350px] rounded-xl object-cover shadow-xl md:h-[350px] md:w-[500px]'
-                alt={project.title}
-                loading='lazy'
-                decoding='async'
-              />
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className='relative z-20 flex w-full snap-x snap-mandatory overflow-y-hidden overflow-x-auto scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun'>
+        {sorted.map(project => (
+          <div
+            key={project.projectId}
+            className='flex h-screen w-screen shrink-0 snap-center flex-col items-center justify-center space-y-5 p-20 md:p-44'>
+            <motion.img
+              initial={{ opacity: 0, y: -300 }}
+              transition={{ duration: 1.2 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              src={project?.image && imageSrc(project.image, 800)}
+              className='h-[250px] w-[350px] rounded-xl object-cover shadow-xl md:h-[350px] md:w-[500px]'
+              alt={project.title}
+              loading='lazy'
+              decoding='async'
+            />
 
-              <div className='max-w-6xl space-y-3 px-0 md:space-y-5 md:px-10'>
-                <h3 className='text-1xl text-center font-semibold'>
-                  <span className='underline decoration-sun underline-offset-4'>
-                    Project {project.projectId} of {projects.length}:
-                  </span>{' '}
-                  {project.title}
-                </h3>
+            <div className='max-w-6xl space-y-3 px-0 md:space-y-5 md:px-10'>
+              <h3 className='text-1xl text-center font-semibold'>
+                <span className='underline decoration-sun underline-offset-4'>
+                  Project {project.projectId} of {projects.length}:
+                </span>{' '}
+                {project.title}
+              </h3>
 
-                {project?.technologies?.length > 0 && (
-                  <div className='flex items-center justify-center space-x-2'>
-                    {project.technologies.map(technology => (
-                      <img
-                        key={technology._id}
-                        className='h-6 w-6 rounded-full object-cover md:h-10 md:w-10'
-                        src={imageSrc(technology.image, 80)}
-                        alt={technology.title}
-                        loading='lazy'
-                        decoding='async'
-                      />
-                    ))}
-                  </div>
-                )}
+              {project?.technologies?.length > 0 && (
+                <div className='flex items-center justify-center space-x-2'>
+                  {project.technologies.map(technology => (
+                    <img
+                      key={technology._id}
+                      className='h-6 w-6 rounded-full object-cover md:h-10 md:w-10'
+                      src={imageSrc(technology.image, 80)}
+                      alt={technology.title}
+                      loading='lazy'
+                      decoding='async'
+                    />
+                  ))}
+                </div>
+              )}
 
-                <p className='text-center text-sm md:text-left'>{project.summary}</p>
-              </div>
+              <p className='text-center text-sm md:text-left'>{project.summary}</p>
             </div>
-          ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Swipe indicator — shows position across the horizontal project carousel */}
+      <div className='absolute bottom-16 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 md:bottom-10'>
+        {sorted.map((project, i) => (
+          <button
+            key={project.projectId}
+            type='button'
+            onClick={() => goTo(i)}
+            aria-label={`Go to project ${i + 1} of ${sorted.length}`}
+            aria-current={active === i}
+            className={`h-2 rounded-full transition-all duration-300 ${
+              active === i ? 'w-6 bg-sun' : 'w-2 bg-gray-500 hover:bg-gray-400'
+            }`}
+          />
+        ))}
       </div>
 
       <div className='absolute left-0 top-[30%] h-[500px] w-full -skew-y-12 bg-sun/10' />

--- a/src/components/Skill.tsx
+++ b/src/components/Skill.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'motion/react'
+import { useState } from 'react'
 
 import { imageSrc } from '../lib/sanity'
 import type { Skill as SkillType } from '../types'
@@ -9,25 +10,35 @@ type Props = {
 }
 
 const Skill = ({ skill, directionLeft }: Props) => {
+  // Desktop reveals the proficiency on hover; touch flips it on tap. The % is
+  // always in the aria-label so screen readers get it without any interaction.
+  const [active, setActive] = useState(false)
+
   return (
-    <div className='group relative flex cursor-pointer'>
+    <button
+      type='button'
+      onClick={() => setActive(a => !a)}
+      aria-label={`${skill.title}: ${skill.progress}% proficiency`}
+      className='group relative flex rounded-full bg-transparent p-0'>
       <motion.img
-        className='rounded-full object-cover w-14 h-14 md:w-18 md:h-18 lg:w-20 lg:h-20 xl:h-24 xl:w-24 filter group-hover:grayscale transition duration-300 ease-in-out'
+        className={`h-14 w-14 rounded-full object-cover transition duration-300 ease-in-out group-hover:grayscale md:h-18 md:w-18 lg:h-20 lg:w-20 xl:h-24 xl:w-24 ${active ? 'grayscale' : ''}`}
         src={imageSrc(skill.image, 200)}
-        alt={skill.title}
+        alt=''
         loading='lazy'
         decoding='async'
-        initial={{ x: directionLeft ? -200 : 200, opacity: 0 }}
+        // Keep the offset small: a large x pushes edge-column icons fully
+        // off-screen on mobile, so whileInView never fires and they stay stuck.
+        initial={{ x: directionLeft ? -50 : 50, opacity: 0 }}
         whileInView={{ opacity: 1, x: 0 }}
-        transition={{ duration: 1 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
       />
 
-      <div className='absolute opacity-0 group-hover:opacity-80 transition ease-in-out duration-300 group-hover:bg-white w-14 h-14 md:w-18 md:h-18 lg:w-20 lg:h-20 xl:h-24 xl:w-24 rounded-full z-0'>
-        <div className='flex items-center justify-center h-full'>
-          <p className='text-sm lg:text-3xl font-bold opacity-100 text-black'>{skill.progress}%</p>
-        </div>
+      <div
+        className={`absolute z-0 flex h-14 w-14 items-center justify-center rounded-full transition duration-300 ease-in-out group-hover:bg-white group-hover:opacity-80 md:h-18 md:w-18 lg:h-20 lg:w-20 xl:h-24 xl:w-24 ${active ? 'bg-white opacity-80' : 'opacity-0'}`}>
+        <p className='text-sm font-bold text-black lg:text-3xl'>{skill.progress}%</p>
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -6,25 +6,28 @@ import Skill from './Skill'
 type Props = { skills: SkillType[] }
 
 const Skills = ({ skills }: Props) => {
-  skills?.sort((a, b) => b.progress - a.progress)
+  const sorted = [...(skills ?? [])].sort((a, b) => b.progress - a.progress)
+  const half = Math.ceil(sorted.length / 2)
 
   return (
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
-      className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center text-center md:text-left xl:flex-row xl:space-y-0 xl:px-10'>
-      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Skills</h2>
+      className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center gap-8 px-4 py-24 text-center'>
+      <div className='flex flex-col items-center gap-2'>
+        <h2 className='text-2xl uppercase tracking-[10px] text-gray-500 sm:tracking-[20px]'>Skills</h2>
+        <h3 className='text-sm uppercase tracking-[3px] text-gray-400'>Hover or tap a skill for proficiency</h3>
+      </div>
 
-      <h3 className='absolute top-36 uppercase tracking-[3px]'>Hover over a skill for current proficiency</h3>
-
-      <div className='absolute top-[205px] grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-5'>
-        {skills?.slice(0, skills.length / 2).map(skill => <Skill key={skill._id} skill={skill} />)}
-
-        {/* Get second half of skills and map with direction left */}
-        {skills
-          ?.slice(skills.length / 2, skills.length)
-          .map(skill => <Skill key={skill._id} skill={skill} directionLeft />)}
+      <div className='grid grid-cols-4 place-items-center gap-3 sm:gap-4 lg:grid-cols-8 md:gap-5'>
+        {sorted.slice(0, half).map(skill => (
+          <Skill key={skill._id} skill={skill} />
+        ))}
+        {/* Second half slides in from the opposite direction */}
+        {sorted.slice(half).map(skill => (
+          <Skill key={skill._id} skill={skill} directionLeft />
+        ))}
       </div>
     </motion.div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -41,7 +41,7 @@
 }
 
 @utility heroButton {
-  @apply rounded-full border border-gray-14 px-6 py-2 text-xs uppercase tracking-widest text-gray-500 transition-colors duration-200 hover:border-sun hover:text-sun;
+  @apply inline-flex min-h-12 items-center justify-center rounded-full border border-gray-20 px-6 py-2 text-xs uppercase tracking-widest text-gray-500 transition-colors duration-200 hover:border-sun hover:text-sun md:min-h-0;
 }
 @utility contactInput {
   @apply rounded-xs border-b border-gray-14 bg-slate-400/10 px-2 py-2 md:px-3 md:py-2 text-gray-500 placeholder-gray-500 outline-hidden transition-all hover:border-sun/40 focus:border-sun/40 focus:text-sun/40;
@@ -67,7 +67,7 @@
 */
 @media (max-width: 639px) {
   header .social-icon {
-    height: 1.875rem !important;
-    width: 1.875rem !important;
+    height: 2.25rem !important;
+    width: 2.25rem !important;
   }
 }


### PR DESCRIPTION
## Design Step 2 — `ux/mobile-responsive-overhaul`

Fixes the mobile layout & interaction bugs from `DESIGN_AUDIT.md`. **Desktop identity preserved**; verified at 320 / 375 / 1280px. Lighthouse: a11y **96 → 97**, perf 90, best-practices 100, SEO 100.

### The 5 headline fixes
1. **Experience cards no longer stuck greyed-out on touch** — they revealed on hover, which doesn't exist on touch. Now **tap/Enter toggles** full opacity (per your call: reveal-on-tap); hover-reveal stays a desktop flourish. Keyboard-operable (`role=button`, `aria-pressed`, focus-visible reveal).
2. **Skills grid no longer scatters** — root cause found: the `initial x:±200` offset pushed edge-column icons **fully off-screen** on narrow viewports, so `whileInView` never fired and they stayed stuck (measured at x=394–462 in a 260px grid). Reduced to ±50 so they stay on-screen; also replaced the brittle `absolute top-[205px]` with in-flow layout. Grid now settles into a clean 4-col (mobile) / 8-col (desktop) grid.
3. **"About" label no longer overlaps the photo** on mobile.
4. **Hero `<h1>` CLS fixed** — the `h-[20px]` (which actually rendered 80px) is gone; stable min-height reserved so the typewriter doesn't shift layout.
5. **Nav pills are now real, tappable pills** — visible borders, **48px touch targets**, wrapping flex row. Also fixes the invalid `<a><button>` nesting (now anchor-pills).

### Also
- **Skills proficiency** is now **tap-to-flip** on touch (per your call), hover on desktop; each icon is a `<button>` with the % in its `aria-label` (screen readers always get it).
- **Experience date** drops the weekday: *"FRI MAR 01 2024"* → *"Mar 2024"*.
- **Removed the defunct Google+ social icon** (linked to an old Drive résumé; redundant now).
- **Projects swipe indicator** — position dots for the 10-project carousel (also jump-to-project).
- Header social icons bumped to 36px on small screens (room freed by removing the 7th icon).

### Flagged as intentional (minor desktop change)
The signature Skills slide-in offset shrank from ±200 to ±50px so it works on mobile — the desktop entrance is subtler but no longer breaks on phones. Interaction reveals (Experience/Skills) are also click-toggleable on desktop now, in addition to hover.

### Verification
- Build / lint / `tsc` green ✅
- No horizontal overflow in any section at 320/375/1280 ✅
- Reveal-on-tap (opacity 0.4→1, aria-pressed), tap-to-flip % (overlay 0→0.8, aria-label carries %), swipe dots (10, active tracked), 48px nav pills — all measured ✅
- Desktop preserved: 8-col skills, hover-dim experience, balanced hero ✅

Next: Step 3 (`ux/spacing-grid-alignment` — fluid clamp() type/spacing tokens, left-align mobile copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)