### PR TITLE
feat(ux): fluid spacing/type tokens & alignment (Design Step 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,31 @@ npm run lint       # ESLint — must pass
 5. **Content source of truth:** `MohammedNayeem_SeniorReactDeveloper_ClaudeCreated.docx` (the old-version DOCX is reference only). Never invent roles, dates, or metrics.
 6. Git identity for this repo: personal email (`nayeem.gmit@gmail.com`), not the WPP one — set via repo-local `git config`.
 
+## CSS architecture & design tokens
+
+Tailwind v4, CSS-first. All theme values live in the `@theme` block in
+`src/index.css` (colors, fonts, and the fluid tokens below). Reusable
+multi-property patterns are `@utility` classes in the same file.
+
+**Design tokens** (fluid via `clamp()` — scale smoothly 320px→desktop; both
+endpoints match the historical fixed values so desktop is unchanged):
+
+| Token | Purpose | Range (mobile → desktop) |
+|-------|---------|--------------------------|
+| `--text-label` | section marker font-size | 18px → 24px |
+| `--tracking-label` | section marker letter-spacing | 6.4px → 20px |
+| `--spacing-gutter` | section horizontal padding (`px-gutter`) | 24px → 40px |
+
+**Utilities** (`@utility` in `index.css`): `heroButton` (nav pills, 48px touch
+target on mobile), `contactInput` (form fields), `sectionLabel` (the unified
+`ABOUT / EXPERIENCE / …` markers — applies the label tokens above).
+
+**UI/UX constraints:** preserve the dark identity, radial hero, and typographic
+layout — polish, don't redesign. Interactive reveals must work on touch (no
+hover-only content). Respect `prefers-reduced-motion`. Keep touch targets large
+and section labels off the viewport edges via the fluid tokens.
+
 ## Roadmap
 
-See `ANALYSIS.md` §4 for the PR-by-PR roadmap and merge order.
+See `ANALYSIS.md` §4 for the engineering roadmap and `DESIGN_AUDIT.md` for the
+UX/design roadmap (Steps 2–5) and merge order.

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -11,8 +11,8 @@ const About = ({ pageInfo }: Props) => {
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
-      className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-start px-10 pt-32 text-center md:flex-row md:justify-evenly md:pt-0 md:text-left'>
-      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>About</h2>
+      className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-start px-gutter pt-32 text-center md:flex-row md:justify-evenly md:pt-0 md:text-left'>
+      <h2 className='sectionLabel absolute top-20 md:top-24'>About</h2>
 
       <motion.img
         src={pageInfo?.profilePic && imageSrc(pageInfo.profilePic, 640)}
@@ -26,12 +26,12 @@ const About = ({ pageInfo }: Props) => {
         className='mb-3 h-44 w-44 shrink-0 rounded-full object-cover md:mb-0 md:h-96 md:w-64 md:rounded-lg xl:h-[600px] xl:w-[500px]'
       />
 
-      <div className='max-sm:max-h-[500px] space-y-4 px-0 md:space-y-10 md:px-10'>
-        <h3 className='text-4xl font-semibold'>
+      <div className='max-sm:max-h-[500px] space-y-4 px-0 text-left md:space-y-10 md:px-10 md:text-left'>
+        <h3 className='text-center text-4xl font-semibold md:text-left'>
           Here is a <span className='underline decoration-sun underline-offset-4'>little</span> background
         </h3>
 
-        <p className='text-balance overflow-y-scrollbar-track-gray-400/20 max-sm:max-h-[450px] overflow-y-auto text-sm scrollbar-thin scrollbar-thumb-sun/80'>
+        <p className='max-sm:max-h-[450px] overflow-y-auto text-sm leading-relaxed scrollbar-thin scrollbar-thumb-sun/80 md:text-base'>
           {pageInfo?.backgroundInformation}
         </p>
       </div>

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -24,11 +24,11 @@ const ContactMe = ({ pageInfo }: Props) => {
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
-      className='relative z-0 mx-auto flex h-screen max-w-7xl flex-col items-center justify-evenly px-10 text-center md:flex-row md:text-left'>
-      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Contact Me</h2>
+      className='relative z-0 mx-auto flex h-screen max-w-7xl flex-col items-center justify-evenly px-gutter text-center md:flex-row md:text-left'>
+      <h2 className='sectionLabel absolute top-20 md:top-24'>Contact Me</h2>
 
       <div className='flex flex-col space-y-5'>
-        <h3 className='text-balance text-center font-semibold'>
+        <h3 className='text-balance text-center text-xl font-semibold md:text-3xl'>
           I have got just the right skills to help you with your project.{' '}
           <span className='underline decoration-sun/50 underline-offset-4'>Let&apos;s talk!</span>
         </h3>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -27,7 +27,7 @@ const Projects = ({ projects }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative z-0 mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden text-left md:flex-row'>
-      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Projects</h2>
+      <h2 className='sectionLabel absolute top-20 md:top-24'>Projects</h2>
 
       <div
         ref={scrollRef}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -14,9 +14,9 @@ const Skills = ({ skills }: Props) => {
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
-      className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center gap-8 px-4 py-24 text-center'>
+      className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center gap-8 px-gutter py-24 text-center'>
       <div className='flex flex-col items-center gap-2'>
-        <h2 className='text-2xl uppercase tracking-[10px] text-gray-500 sm:tracking-[20px]'>Skills</h2>
+        <h2 className='sectionLabel'>Skills</h2>
         <h3 className='text-sm uppercase tracking-[3px] text-gray-400'>Hover or tap a skill for proficiency</h3>
       </div>
 

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -12,7 +12,7 @@ const WorkExperience = ({ experiences }: Props) => {
       whileInView={{ opacity: 1 }}
       transition={{ duration: 1.5 }}
       className='relative mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden md:px-10 text-left md:flex-row'>
-      <h2 className='absolute top-20 text-2xl uppercase tracking-[20px] text-gray-500 md:top-24'>Experience</h2>
+      <h2 className='sectionLabel absolute top-20 md:top-24'>Experience</h2>
       <div className='flex w-full snap-x snap-mandatory space-x-5 overflow-x-auto p-10 scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun/80'>
         {experiences
           ?.sort((a, b) => b.jobId - a.jobId)

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,17 @@
   --color-gray: #e5e5e5;
 
   --font-basefont: CascadiaMono, Consolas, monospace;
+
+  /*
+    Fluid design tokens — scale smoothly between 320px and desktop via clamp().
+    Endpoints match the previous fixed values (desktop preserved), while the
+    mobile end is dialled down so nothing crowds the viewport edges.
+      --text-label / --tracking-label : the uppercase section markers
+      --spacing-gutter                : consistent section horizontal padding
+  */
+  --text-label: clamp(1.125rem, 0.9rem + 1.1vw, 1.5rem);
+  --tracking-label: clamp(0.4rem, 0.05rem + 1.5vw, 1.25rem);
+  --spacing-gutter: clamp(1.5rem, 0.5rem + 4vw, 2.5rem);
 }
 
 /*
@@ -45,6 +56,15 @@
 }
 @utility contactInput {
   @apply rounded-xs border-b border-gray-14 bg-slate-400/10 px-2 py-2 md:px-3 md:py-2 text-gray-500 placeholder-gray-500 outline-hidden transition-all hover:border-sun/40 focus:border-sun/40 focus:text-sun/40;
+}
+
+/* Unified, fluid section marker (ABOUT / EXPERIENCE / SKILLS / …) */
+@utility sectionLabel {
+  font-size: var(--text-label);
+  letter-spacing: var(--tracking-label);
+  line-height: 1.4;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
 }
 
 @layer base {


### PR DESCRIPTION
## Design Step 3 — `ux/spacing-grid-alignment`

Introduces a small **fluid design-token system** (clamp-based) and applies it for consistent, readable scaling. **Desktop endpoints preserved** — section labels measured at exactly **24px/20px on desktop**, gracefully down to **18px/6.4px at 320px**. No overflow 320–1280.

### Design tokens (in `@theme`, `src/index.css`)
| Token | Purpose | Mobile → Desktop |
|-------|---------|------------------|
| `--text-label` | section marker size | 18px → 24px |
| `--tracking-label` | section marker letter-spacing | 6.4px → 20px |
| `--spacing-gutter` (`px-gutter`) | section horizontal padding | 24px → 40px |

### Applied
- **New `sectionLabel` utility** unifies all five ABOUT / EXPERIENCE / SKILLS / PROJECTS / CONTACT markers (previously copy-pasted `text-2xl tracking-[20px]` that crowded the mobile edges). Now consistent and fluid.
- **About bio left-aligned on mobile** (was centre-aligned — a ragged, hard-to-read wall of text), with `leading-relaxed` and a slightly larger desktop body. Heading stays centred on mobile. Uses `px-gutter`.
- **Skills + Contact** adopt `px-gutter` for consistent section gutters.
- **Contact CTA heading** given a real responsive size (`text-xl md:text-3xl`) — it had been rendering at 16px because its original fluid sizing (a broken `min()` value) never worked.

### Documented
CLAUDE.md now has a **CSS architecture & design tokens** section (token table, utilities, UI/UX constraints).

### Flagged (intentional, subtle)
The Contact CTA heading grows from 16px to 20/30px — a deliberate fix (16px was too small for a main heading). Section labels shrink on mobile only (desktop unchanged).

### Verification
- Build / lint / `tsc` green ✅
- Section labels: 24px/20px @1280 (preserved), 18px/6.4px @320 ✅
- About body left-aligned on mobile ✅; no overflow across 320/375/1280 ✅

Next: Step 4 (`ux/motion-micro-interactions` — `prefers-reduced-motion`, `viewport once` on section fades, tactile hover + focus states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)