### PR TITLE
feat(ux): motion polish, reduced-motion support & tactile hovers (Design Step 4)

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -10,7 +10,8 @@ const About = ({ pageInfo }: Props) => {
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      transition={{ duration: 1.5 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8 }}
       className='relative mx-auto flex h-screen max-w-7xl flex-col items-center justify-start px-gutter pt-32 text-center md:flex-row md:justify-evenly md:pt-0 md:text-left'>
       <h2 className='sectionLabel absolute top-20 md:top-24'>About</h2>
 

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -23,7 +23,8 @@ const ContactMe = ({ pageInfo }: Props) => {
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      transition={{ duration: 1.5 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8 }}
       className='relative z-0 mx-auto flex h-screen max-w-7xl flex-col items-center justify-evenly px-gutter text-center md:flex-row md:text-left'>
       <h2 className='sectionLabel absolute top-20 md:top-24'>Contact Me</h2>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,7 +29,7 @@ const Header = ({ socials }: Props) => {
               url={social.url}
               fgColor='currentColor'
               bgColor='transparent'
-              className='text-gray-500 transition-colors duration-200 hover:text-sun'
+              className='text-gray-500 transition duration-200 hover:text-sun motion-safe:hover:scale-110'
             />
           ))}
       </motion.div>
@@ -50,7 +50,7 @@ const Header = ({ socials }: Props) => {
             network='email'
             fgColor='currentColor'
             bgColor='transparent'
-            className='text-gray-500 transition-colors duration-200 hover:text-sun'
+            className='text-gray-500 transition duration-200 hover:text-sun motion-safe:hover:scale-110'
             url=''
           />
           <p className='hidden cursor-pointer text-sm uppercase text-gray-400 md:inline-flex'>Get in touch</p>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -25,7 +25,8 @@ const Projects = ({ projects }: Props) => {
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      transition={{ duration: 1.5 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8 }}
       className='relative z-0 mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden text-left md:flex-row'>
       <h2 className='sectionLabel absolute top-20 md:top-24'>Projects</h2>
 
@@ -42,8 +43,9 @@ const Projects = ({ projects }: Props) => {
               transition={{ duration: 1.2 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
+              whileHover={{ scale: 1.03 }}
               src={project?.image && imageSrc(project.image, 800)}
-              className='h-[250px] w-[350px] rounded-xl object-cover shadow-xl md:h-[350px] md:w-[500px]'
+              className='h-[250px] w-[350px] cursor-pointer rounded-xl object-cover shadow-xl transition-shadow hover:shadow-2xl hover:shadow-sun/20 md:h-[350px] md:w-[500px]'
               alt={project.title}
               loading='lazy'
               decoding='async'

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -13,7 +13,8 @@ const Skills = ({ skills }: Props) => {
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      transition={{ duration: 1.5 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8 }}
       className='relative mx-auto flex min-h-screen max-w-[2000px] flex-col items-center justify-center gap-8 px-gutter py-24 text-center'>
       <div className='flex flex-col items-center gap-2'>
         <h2 className='sectionLabel'>Skills</h2>

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -10,7 +10,8 @@ const WorkExperience = ({ experiences }: Props) => {
     <motion.div
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
-      transition={{ duration: 1.5 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8 }}
       className='relative mx-auto flex h-screen max-w-full flex-col items-center justify-evenly overflow-hidden md:px-10 text-left md:flex-row'>
       <h2 className='sectionLabel absolute top-20 md:top-24'>Experience</h2>
       <div className='flex w-full snap-x snap-mandatory space-x-5 overflow-x-auto p-10 scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun/80'>

--- a/src/index.css
+++ b/src/index.css
@@ -52,7 +52,7 @@
 }
 
 @utility heroButton {
-  @apply inline-flex min-h-12 items-center justify-center rounded-full border border-gray-20 px-6 py-2 text-xs uppercase tracking-widest text-gray-500 transition-colors duration-200 hover:border-sun hover:text-sun md:min-h-0;
+  @apply inline-flex min-h-12 items-center justify-center rounded-full border border-gray-20 px-6 py-2 text-xs uppercase tracking-widest text-gray-500 transition duration-200 hover:border-sun hover:text-sun motion-safe:hover:-translate-y-0.5 md:min-h-0;
 }
 @utility contactInput {
   @apply rounded-xs border-b border-gray-14 bg-slate-400/10 px-2 py-2 md:px-3 md:py-2 text-gray-500 placeholder-gray-500 outline-hidden transition-all hover:border-sun/40 focus:border-sun/40 focus:text-sun/40;
@@ -77,6 +77,23 @@
 
   body {
     font-family: 'Inter Variable', sans-serif;
+  }
+}
+
+/*
+  Respect the OS "reduce motion" setting for CSS-driven animation that motion's
+  MotionConfig can't reach — the hero's animate-ping / animate-pulse rings and
+  the pulsing contact icons. Near-instant durations neutralise the movement
+  while leaving the layout intact.
+*/
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { MotionConfig } from 'motion/react'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
@@ -8,6 +9,11 @@ import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    {/* reducedMotion="user" makes every motion component honor the OS
+        "reduce motion" setting: transform/layout animations are skipped
+        (elements appear in place), gentle opacity fades still play. */}
+    <MotionConfig reducedMotion='user'>
+      <App />
+    </MotionConfig>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Design Step 4 — `ux/motion-micro-interactions`

### `prefers-reduced-motion` — now fully respected
- App wrapped in **`<MotionConfig reducedMotion="user">`** — every `motion` component honors the OS setting (slide/transform animations skipped; gentle opacity fades still play).
- A **`prefers-reduced-motion` CSS guard** covers what MotionConfig can't reach: the hero's `animate-ping`/`animate-pulse` rings and the pulsing contact icons.
- _Verified via compiled output_ (the preview host can't emulate the media feature): the `@media (prefers-reduced-motion: reduce)` rule is in the built CSS and `reducedMotion` is in the JS bundle.

### Snappier, non-repeating entrances
- **`viewport={{ once: true }}`** on all five section-wrapper fades (About / Experience / Skills / Projects / Contact) — they were **re-running every time you scrolled past**. Duration trimmed **1.5s → 0.8s** for a more modern feel.

### Tactile micro-interactions (all `motion-safe`)
Gated with `motion-safe:` so reduced-motion users get none of the movement:
- **Nav pills** lift on hover (`-translate-y-0.5`).
- **Social icons** scale to 110% on hover.
- **Project image** scales (`whileHover 1.03`) with a soft sun-tinted shadow.

### Verification
- Build / lint / `tsc` green ✅
- Reduced-motion CSS rule + MotionConfig confirmed in the compiled bundle ✅
- Hover transitions wired on pills + social icons (measured); desktop hero renders unchanged ✅
- Static appearance identical in normal mode — motion changes only affect scroll-entrances, hover, and reduced-motion users ✅

Next: Step 5 (`ux/a11y-keyboard-nav` — `:focus-visible` rings across all interactive elements, restore the input outline, fix the nested/empty header email anchor, final touch-target/label pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)