### PR TITLE
feat(ux): keyboard focus rings & a11y polish (Design Step 5 — final)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { EnvelopeIcon } from '@heroicons/react/24/solid'
 import { motion } from 'motion/react'
 import { SocialIcon } from 'react-social-icons'
 
@@ -45,15 +46,12 @@ const Header = ({ socials }: Props) => {
         className='flex flex-row items-center gap-3 md:gap-4'>
         <ResumeDownload />
 
-        <a href='#contact' className='flex flex-row items-center'>
-          <SocialIcon
-            network='email'
-            fgColor='currentColor'
-            bgColor='transparent'
-            className='text-gray-500 transition duration-200 hover:text-sun motion-safe:hover:scale-110'
-            url=''
-          />
-          <p className='hidden cursor-pointer text-sm uppercase text-gray-400 md:inline-flex'>Get in touch</p>
+        <a
+          href='#contact'
+          aria-label='Get in touch'
+          className='flex flex-row items-center gap-2 rounded-full text-gray-500 transition-colors duration-200 hover:text-sun'>
+          <EnvelopeIcon className='h-6 w-6 transition-transform duration-200 motion-safe:hover:scale-110' />
+          <span className='hidden text-sm uppercase text-gray-400 md:inline-flex'>Get in touch</span>
         </a>
       </motion.div>
     </header>

--- a/src/index.css
+++ b/src/index.css
@@ -49,13 +49,26 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  /*
+    Consistent keyboard focus indicator for every interactive element — nav
+    pills, skill/experience buttons, social links, the résumé disclosure, form
+    fields, and the back-to-top control. :focus-visible keeps it keyboard-only
+    (no ring on mouse click), and modern browsers round the outline to the
+    element's border-radius.
+  */
+  :focus-visible {
+    outline: 2px solid var(--color-sun);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
 }
 
 @utility heroButton {
   @apply inline-flex min-h-12 items-center justify-center rounded-full border border-gray-20 px-6 py-2 text-xs uppercase tracking-widest text-gray-500 transition duration-200 hover:border-sun hover:text-sun motion-safe:hover:-translate-y-0.5 md:min-h-0;
 }
 @utility contactInput {
-  @apply rounded-xs border-b border-gray-14 bg-slate-400/10 px-2 py-2 md:px-3 md:py-2 text-gray-500 placeholder-gray-500 outline-hidden transition-all hover:border-sun/40 focus:border-sun/40 focus:text-sun/40;
+  @apply rounded-xs border-b border-gray-14 bg-slate-400/10 px-2 py-2 md:px-3 md:py-2 text-gray-500 placeholder-gray-500 transition-all hover:border-sun/40 focus:border-sun/40 focus:text-sun/40;
 }
 
 /* Unified, fluid section marker (ABOUT / EXPERIENCE / SKILLS / …) */


### PR DESCRIPTION
## Design Step 5 — `ux/a11y-keyboard-nav` (final design step)

### Consistent keyboard focus indicators
- A single global **`:focus-visible`** rule — a **2px sun ring** with offset, rounded to each element's shape — so every interactive element gets the same keyboard-only focus indicator: nav pills, skill & experience buttons, social links, the résumé disclosure, form fields, and the back-to-top control.
- **Restored the form-input focus ring**: `contactInput` used `outline-hidden`, which suppressed it entirely. Removed so the ring shows.

### Header markup fix
The "Get in touch" control nested an **empty `<a href="">`** inside the `<a href="#contact">` wrapper — invalid nested-interactive markup. Replaced with a single anchor containing a heroicons `EnvelopeIcon` + `aria-label`. The résumé/email right-cluster is now visually consistent (both 24px).

### Verification
- Build / lint / `tsc` green ✅
- `:focus-visible` sun-ring rule confirmed in compiled CSS; input `outline-hidden` removed ✅
- Header: 0 nested anchors, SVG envelope icon, aria-label present ✅
- **Lighthouse: a11y 97, best-practices 100, SEO 100, perf 91** — no regressions; only the intentional muted contrast remains ✅

### 🎉 Completes the design phase (Steps 1–5)
Audit → mobile overhaul → fluid tokens → motion/reduced-motion → focus/a11y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)