### PR TITLE
fix(ux): header icon scaling + hero typewriter layout shift

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -50,7 +50,7 @@ const Header = ({ socials }: Props) => {
           href='#contact'
           aria-label='Get in touch'
           className='flex flex-row items-center gap-2 rounded-full text-gray-500 transition-colors duration-200 hover:text-sun'>
-          <EnvelopeIcon className='h-6 w-6 transition-transform duration-200 motion-safe:hover:scale-110' />
+          <EnvelopeIcon className='h-8 w-8 transition-transform duration-200 motion-safe:hover:scale-110 sm:h-9 sm:w-9' />
           <span className='hidden text-sm uppercase text-gray-400 md:inline-flex'>Get in touch</span>
         </a>
       </motion.div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -31,7 +31,7 @@ const Hero = ({ pageInfo }: Props) => {
           {pageInfo?.role}
         </p>
 
-        <h1 className='flex min-h-24 items-center justify-center py-6 text-2xl font-semibold text-white md:min-h-20 md:text-5xl lg:text-6xl'>
+        <h1 className='my-4 flex min-h-[2lh] items-center justify-center text-2xl font-semibold text-white md:text-5xl lg:min-h-[1lh] lg:text-6xl'>
           <span className='mr-3 font-mono'>{text}</span>
           <Cursor cursorColor='#D92815' />
         </h1>

--- a/src/components/ResumeDownload.tsx
+++ b/src/components/ResumeDownload.tsx
@@ -38,7 +38,7 @@ const ResumeDownload = () => {
       <summary
         className='flex min-h-6 cursor-pointer list-none items-center gap-1.5 text-sm uppercase text-gray-400 transition-colors duration-200 hover:text-sun [&::-webkit-details-marker]:hidden'
         aria-label='Download résumé'>
-        <ArrowDownTrayIcon className='h-6 w-6' />
+        <ArrowDownTrayIcon className='h-8 w-8 sm:h-9 sm:w-9' />
         <span className='hidden md:inline'>Résumé</span>
       </summary>
 


### PR DESCRIPTION
Two issues reported after the design phase:

### 1. Right-side header icons didn't scale
The résumé-download and email ("get in touch") icons were a **fixed 24px**, while the left social icons scale 36px→50px — so on larger screens the right side looked progressively too small. They now scale **h-8 → h-9 (32px → 36px)**, balanced against both the social row and their text labels. _(Kept a touch smaller than the label-less social icons since these have labels.)_

### 2. Hero typewriter caused a layout shift
The `<h1>` reserved `min-h-24` (96px), but its `py-6` padding pushed the **two-line** strings ("Hi, I am Mohammed Nayeem", "Guy-who-loves-Coffee.tsx") to 112px while the **one-line** "<ButLovesToCodeMore />" stayed at 96px — a **16px jump that shifted the nav pills** every cycle. Now it reserves exactly two line-heights (`min-h-[2lh]`, collapsing to one on `lg` where strings never wrap) with no padding, so the box height is constant.

### Verification
- **Issue 2:** all three typewriter strings now yield an **identical h1 height** at 375px (64px) and 1280px (60px) — measured, no shift ✅
- **Issue 1:** right icons 32px→36px across breakpoints, visually balanced with the 36→50px social row (screenshots) ✅
- Build / lint / `tsc` green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)