### PR TITLE
feat(ux): identical header icons + tabbed Experience redesign

### DIFF
--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -7,69 +7,65 @@ type Props = { experience: Experience }
 
 const fmt = (date: string) => new Date(date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 
+/**
+ * Detail panel for the currently selected role in the Experience tab layout.
+ * Keyed on the experience id by the parent so it re-animates on tab change.
+ */
 const ExperienceCard = ({ experience }: Props) => {
   return (
-    <motion.article
-      initial={{ opacity: 0, y: 40 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2 }}
-      transition={{ duration: 0.5 }}
-      className='relative flex h-[520px] w-[85vw] max-w-xl shrink-0 snap-center flex-col overflow-hidden rounded-2xl border border-gray-20 bg-gray-16 md:max-w-2xl'>
-      {/* sun accent bar */}
-      <span className='h-1 w-full shrink-0 bg-sun/80' />
-
-      <div className='flex min-h-0 flex-1 flex-col p-6 md:p-8'>
-        {/* header */}
-        <header className='flex items-center gap-4 border-b border-gray-20 pb-5'>
-          <img
-            src={imageSrc(experience.companyImage, 200)}
-            alt={experience.company}
-            loading='lazy'
-            decoding='async'
-            className='h-16 w-16 shrink-0 rounded-full object-cover object-center md:h-20 md:w-20'
-          />
-          <div className='min-w-0'>
-            <h3 className='text-lg font-bold leading-tight md:text-2xl'>{experience.jobTitle}</h3>
-            <p className='font-semibold text-sun md:text-lg'>{experience.company}</p>
-            <p className='mt-1.5 flex flex-wrap items-center gap-2 text-xs uppercase tracking-wider text-gray-400'>
-              <span>
-                {fmt(experience.dateStarted)} – {experience.isCurrentlyWorkingHere ? 'Present' : fmt(experience.dateEnded)}
-              </span>
-              {experience.isCurrentlyWorkingHere && (
-                <span className='rounded-full bg-sun/15 px-2 py-0.5 font-semibold text-sun'>Current</span>
-              )}
-            </p>
-          </div>
-        </header>
-
-        {/* technologies */}
-        {experience.technologies?.length > 0 && (
-          <div className='flex flex-wrap gap-2 py-4'>
-            {experience.technologies.map(technology => (
-              <img
-                key={technology._id}
-                src={imageSrc(technology.image, 64)}
-                alt={technology.title}
-                title={technology.title}
-                loading='lazy'
-                decoding='async'
-                className='h-7 w-7 rounded-full object-cover'
-              />
-            ))}
-          </div>
-        )}
-
-        {/* highlights */}
-        <ul className='min-h-0 flex-1 space-y-3 overflow-y-auto pr-2 text-sm leading-relaxed text-gray-300 scrollbar-thin scrollbar-thumb-sun/60 md:text-base'>
-          {experience?.points?.map((point, i) => (
-            <li key={i} className='flex gap-3'>
-              <span className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sun' />
-              <span>{point}</span>
-            </li>
-          ))}
-        </ul>
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, ease: 'easeOut' }}
+      className='flex flex-col gap-5'>
+      <div className='flex items-center gap-4'>
+        <img
+          src={imageSrc(experience.companyImage, 200)}
+          alt={experience.company}
+          loading='lazy'
+          decoding='async'
+          className='h-14 w-14 shrink-0 rounded-full object-cover object-center md:h-16 md:w-16'
+        />
+        <div className='min-w-0'>
+          <h3 className='text-lg font-bold leading-tight md:text-2xl'>
+            {experience.jobTitle} <span className='text-sun'>@ {experience.company}</span>
+          </h3>
+          <p className='mt-1 flex flex-wrap items-center gap-2 text-xs uppercase tracking-wider text-gray-400'>
+            <span>
+              {fmt(experience.dateStarted)} – {experience.isCurrentlyWorkingHere ? 'Present' : fmt(experience.dateEnded)}
+            </span>
+            {experience.isCurrentlyWorkingHere && (
+              <span className='rounded-full bg-sun/15 px-2 py-0.5 font-semibold text-sun'>Current</span>
+            )}
+          </p>
+        </div>
       </div>
-    </motion.article>
+
+      {experience.technologies?.length > 0 && (
+        <div className='flex flex-wrap gap-2'>
+          {experience.technologies.map(technology => (
+            <img
+              key={technology._id}
+              src={imageSrc(technology.image, 64)}
+              alt={technology.title}
+              title={technology.title}
+              loading='lazy'
+              decoding='async'
+              className='h-7 w-7 rounded-full object-cover'
+            />
+          ))}
+        </div>
+      )}
+
+      <ul className='max-h-[42vh] space-y-3 overflow-y-auto pr-2 text-sm leading-relaxed text-gray-300 scrollbar-thin scrollbar-thumb-sun/60 md:text-base'>
+        {experience?.points?.map((point, i) => (
+          <li key={i} className='flex gap-3'>
+            <span className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sun' />
+            <span>{point}</span>
+          </li>
+        ))}
+      </ul>
+    </motion.div>
   )
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import { EnvelopeIcon } from '@heroicons/react/24/solid'
 import { motion } from 'motion/react'
 import { SocialIcon } from 'react-social-icons'
 
@@ -46,13 +45,24 @@ const Header = ({ socials }: Props) => {
         className='flex flex-row items-center gap-3 md:gap-4'>
         <ResumeDownload />
 
-        <a
-          href='#contact'
-          aria-label='Get in touch'
-          className='flex flex-row items-center gap-2 rounded-full text-gray-500 transition-colors duration-200 hover:text-sun'>
-          <EnvelopeIcon className='h-8 w-8 transition-transform duration-200 motion-safe:hover:scale-110 sm:h-9 sm:w-9' />
-          <span className='hidden text-sm uppercase text-gray-400 md:inline-flex'>Get in touch</span>
-        </a>
+        {/* Same react-social-icons component as the left row, so it renders
+            identically. The label is a separate sibling link (not a wrapper)
+            to keep it a single, valid anchor. */}
+        <div className='flex flex-row items-center'>
+          <SocialIcon
+            network='email'
+            url='#contact'
+            fgColor='currentColor'
+            bgColor='transparent'
+            aria-label='Get in touch'
+            className='text-gray-500 transition duration-200 hover:text-sun motion-safe:hover:scale-110'
+          />
+          <a
+            href='#contact'
+            className='hidden text-sm uppercase text-gray-400 transition-colors duration-200 hover:text-sun md:inline-flex'>
+            Get in touch
+          </a>
+        </div>
       </motion.div>
     </header>
   )

--- a/src/components/ResumeDownload.tsx
+++ b/src/components/ResumeDownload.tsx
@@ -38,7 +38,7 @@ const ResumeDownload = () => {
       <summary
         className='flex min-h-6 cursor-pointer list-none items-center gap-1.5 text-sm uppercase text-gray-400 transition-colors duration-200 hover:text-sun [&::-webkit-details-marker]:hidden'
         aria-label='Download résumé'>
-        <ArrowDownTrayIcon className='h-8 w-8 sm:h-9 sm:w-9' />
+        <ArrowDownTrayIcon className='h-9 w-9 sm:h-11 sm:w-11' />
         <span className='hidden md:inline'>Résumé</span>
       </summary>
 

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 import type { Experience } from '../types'
 import ExperienceCard from './ExperienceCard'
@@ -8,34 +8,8 @@ type Props = { experiences: Experience[] }
 
 const WorkExperience = ({ experiences }: Props) => {
   const sorted = [...(experiences ?? [])].sort((a, b) => b.jobId - a.jobId)
-  const scrollRef = useRef<HTMLDivElement>(null)
   const [active, setActive] = useState(0)
-
-  const onScroll = () => {
-    const el = scrollRef.current
-    if (!el) return
-    const center = el.scrollLeft + el.clientWidth / 2
-    let best = 0
-    let bestDist = Infinity
-    Array.from(el.children).forEach((c, i) => {
-      const card = c as HTMLElement
-      const dist = Math.abs(card.offsetLeft + card.offsetWidth / 2 - center)
-      if (dist < bestDist) {
-        bestDist = dist
-        best = i
-      }
-    })
-    setActive(best)
-  }
-
-  const goTo = (i: number) => {
-    const el = scrollRef.current
-    if (!el) return
-    const card = el.children[i] as HTMLElement
-    // Jump to the card. Native smooth scrollTo is cancelled by
-    // scroll-snap-type: mandatory here, so set scrollLeft directly.
-    el.scrollLeft = card.offsetLeft - (el.clientWidth - card.offsetWidth) / 2
-  }
+  const current = sorted[active]
 
   return (
     <motion.div
@@ -43,32 +17,36 @@ const WorkExperience = ({ experiences }: Props) => {
       whileInView={{ opacity: 1 }}
       viewport={{ once: true }}
       transition={{ duration: 0.8 }}
-      className='relative mx-auto flex h-screen w-full flex-col items-center justify-center overflow-hidden'>
+      className='relative mx-auto flex h-screen w-full max-w-5xl flex-col items-center justify-center gap-10 px-gutter'>
       <h2 className='sectionLabel absolute top-20 md:top-24'>Experience</h2>
 
-      <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        className='flex w-full snap-x snap-mandatory items-center gap-6 overflow-x-auto px-[max(1.5rem,calc((100vw_-_42rem)/2))] py-10 scrollbar-thin scrollbar-track-gray-400/20 scrollbar-thumb-sun/80 md:gap-8'>
-        {sorted.map(experience => (
-          <ExperienceCard key={experience.jobId} experience={experience} />
-        ))}
-      </div>
+      <div className='mt-16 flex w-full flex-col gap-6 md:mt-0 md:flex-row md:gap-10'>
+        {/* Company tabs — horizontal strip on mobile, vertical rail on desktop */}
+        <div
+          role='tablist'
+          aria-label='Companies'
+          className='-mx-gutter flex gap-1 overflow-x-auto px-gutter pb-1 scrollbar-none md:mx-0 md:w-52 md:shrink-0 md:flex-col md:gap-0 md:overflow-visible md:px-0'>
+          {sorted.map((experience, i) => (
+            <button
+              key={experience.jobId}
+              type='button'
+              role='tab'
+              aria-selected={active === i}
+              onClick={() => setActive(i)}
+              className={`shrink-0 whitespace-nowrap px-4 py-3 text-left text-sm font-medium transition-colors duration-200 md:border-l-2 ${
+                active === i
+                  ? 'border-b-2 border-sun text-sun md:border-b-0 md:border-l-2 md:bg-sun/5'
+                  : 'border-b-2 border-transparent text-gray-400 hover:text-white md:border-l-2 md:hover:bg-gray-16'
+              }`}>
+              {experience.company}
+            </button>
+          ))}
+        </div>
 
-      {/* Swipe indicator across the horizontal experience carousel */}
-      <div className='absolute bottom-16 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 md:bottom-10'>
-        {sorted.map((experience, i) => (
-          <button
-            key={experience.jobId}
-            type='button'
-            onClick={() => goTo(i)}
-            aria-label={`Go to experience ${i + 1} of ${sorted.length}`}
-            aria-current={active === i}
-            className={`h-2 rounded-full transition-all duration-300 ${
-              active === i ? 'w-6 bg-sun' : 'w-2 bg-gray-500 hover:bg-gray-400'
-            }`}
-          />
-        ))}
+        {/* Detail panel for the selected role */}
+        <div className='min-h-[22rem] flex-1'>
+          <ExperienceCard key={current?._id} experience={current} />
+        </div>
       </div>
     </motion.div>
   )


### PR DESCRIPTION
Addresses the two issues reported after the last round.

## 1. Header icons now identical to the left
The "Get in touch" email was a solid heroicon envelope (heavy, different system, 36px) next to the left's 50px react-social-icons. Now it uses the **same `react-social-icons` `<SocialIcon>` component** as the left row (`network="email"`, links to `#contact`), so it renders identically — same glyph style, same 50px/36px responsive sizing. Its "GET IN TOUCH" label is a separate sibling link (keeps a single valid anchor). The résumé download arrow is sized up (36→44px) to match the social glyphs.

## 2. Experience — modern, intuitive redesign
Replaced the horizontal card carousel with a **tabbed layout** (the classic modern-portfolio pattern):
- A **company rail** — vertical on desktop, a horizontal scroll strip on mobile.
- A **detail panel** for the selected role: logo, `Role @ Company` (company in sun), dates + a **Current** badge, the role's tech, and highlight bullets with sun bullet-dots.
- **Click a company → see the role.** `role="tab"` / `aria-selected`, the detail panel animates on switch, and bullets scroll within a bounded height so the section stays one screen tall.

### Verification
- Build / lint / `tsc` green
- Tab switching updates the detail (measured: clicking "Wipro Limited" → "Technical Lead @ Wipro Limited")
- Email is a react-social-icons anchor matching the left (50px, verified)
- No horizontal overflow 320–1280; desktop + mobile both checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
